### PR TITLE
FROM docs/982-agro-platform-credit TO development

### DIFF
--- a/decks/slides/onepager.html
+++ b/decks/slides/onepager.html
@@ -239,7 +239,7 @@
     <!-- PLATFORM PROOF -->
     <div style="padding-top:6px;">
       <div class="rounded-lg border border-green-accent/30 bg-green-accent/5 px-4 py-3 text-center">
-        <p class="font-space text-[13px] font-semibold text-foreground">Powered by Orchestra + OpenHarness</p>
+        <p class="font-space text-[13px] font-semibold text-foreground">Powered by Orchestra + AGRO</p>
         <p class="mt-1 text-[9px] text-muted-fg font-light leading-snug">Mifune builds managed AI workers on a production agent platform your team can inspect, extend, and own.</p>
       </div>
       <p class="text-[8px] text-muted-fg text-center mt-1 font-light">Managed AI workers &nbsp;|&nbsp; console.mifune.dev</p>


### PR DESCRIPTION
**Parked as a draft at operator request.** Orchestra is not the active finish line — immediate priority is `mifunedev/agro` and `mifunedev/agro-web`. This draft preserves the change on its own branch. No closing trailer for `mifunedev/agro#944` or `#939`; both stay open.

`Refs #982`, `Refs mifunedev/agro#944`.

## Change

One line in `decks/slides/onepager.html`:

```diff
-Powered by Orchestra + OpenHarness
+Powered by Orchestra + AGRO
```

The runtime was renamed upstream (`mifunedev/agro#939`). Verified live while preparing this: `github.com/mifunedev/agro` returns 200 and `oh.mifune.dev` now redirects to `agro.mifune.dev`.

## Test evidence — exact head `1acc415bf347991ed2dbd3b0d0ac937b9006faa0`

**No CI will run on this branch, and that is expected, not a skipped check.** Both relevant workflows exclude it by design:

- `test.yml` runs on a push to any branch but sets `paths-ignore` including `decks/**`. This change touches only `decks/`, so no test job is triggered.
- `slides.yml` publishes the deck to GitHub Pages, but only on a push to `development` under `decks/slides/**`. A feature branch does not trigger it.

So the merge of this PR — not this PR itself — is what would publish the slide. Flagging that explicitly since it is a customer-facing artifact.

Verification here is therefore the diff itself: a single text substitution inside an HTML text node, changing no markup, class, script, or link.

## Not in this PR

No merge, release, or deployment. No other OpenHarness -> AGRO references were swept in this repository; this fixes the one customer-facing credit line only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Gh4FRUfcQYD6CcNNH1xRU
